### PR TITLE
Adding django debug toolbar

### DIFF
--- a/base_site/settings.py
+++ b/base_site/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'admin_honeypot',
+    'debug_toolbar'
 )
 
 MIDDLEWARE_CLASSES = (
@@ -46,6 +47,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -161,3 +163,6 @@ LOGIN_REDIRECT_URL = 'account_dashboard'
 
 # Django admin honeypot
 ADMIN_HONEYPOT_EMAIL_ADMINS = False
+
+# Django debug toolbar
+INTERNAL_IPS = ('127.0.0.1',)

--- a/base_site/urls.py
+++ b/base_site/urls.py
@@ -46,6 +46,12 @@ urlpatterns = [
     url(r'^api-token-auth/', views.obtain_auth_token),
 ]
 
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]
+
 # We are only want to serve the media directory here for testing purposes
 if settings.DEBUG is True:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,12 @@ coverage==4.2
 dj-database-url==0.4.0
 Django==1.9.2
 django-admin-honeypot==1.0.0
+django-debug-toolbar==1.6
 django-filter==0.15.2
 djangorestframework==3.4.7
 gunicorn==19.4.5
 Markdown==2.6.7
 Pillow==3.3.1
 psycopg2==2.6.1
+sqlparse==0.2.2
 whitenoise==2.0.6


### PR DESCRIPTION
- Added localhost to internal IPs, toolbar should only show for this IP and if debug is turned on.
- Make sure to collectstatic before testing